### PR TITLE
Fix pinball loss

### DIFF
--- a/GP_Beta_cal.py
+++ b/GP_Beta_cal.py
@@ -98,7 +98,7 @@ class GP_Beta:
         else:
             self.kappa = kappa
 
-    def fit(self, y, mu, sigma, n_u, lr=1e-3, optimizer_choice='adam'):
+    def fit(self, y, mu, sigma, n_u, lr=1e-3, optimizer_choice='adam', plot_loss=True):
 
         self.n = numpy.shape(y)[0]
 
@@ -146,7 +146,7 @@ class GP_Beta:
                               self.mu_u.ravel(), self.sigma_u.ravel(), mu_shift])
 
         theta = parameter_update(theta, self.q, self.ln_q, self.ln_1_q, self.ln_s, self.mu, self.sigma,
-                                 self.n_u, self.n, self.jitter, lr=lr, plot_loss=True, optimizer_choice=optimizer_choice)
+                                 self.n_u, self.n, self.jitter, lr=lr, plot_loss=plot_loss, optimizer_choice=optimizer_choice)
 
         c_theta = theta[:8]
 


### PR DESCRIPTION
Hej!

Thanks for providing the datasets and the instructions for how to run your code, and sorry for not coming back to you earlier (I've been busy with preparing some stuff for NeurIPS). I could successfully run the experiments (though I only tried the Bayesian regression model actually), but when I compared the statistical evaluations with my Julia code I noticed that the evaluations of the averaged pinball loss did not match whereas MSE and NLL did.

I think you forgot to average over the number of samples in your implementation of the averaged pinball loss. It seems, you accumulate the loss for all quantile levels but only average over the quantile levels in the end. According to the explanation in your paper, I assume you intended to average over the samples as well. I changed the `get_pin_ball_loss` function accordingly. With the changes in this PR, both the Julia and Python implementation yield values of around 1.4 instead of 160 for the example in the notebook (this corresponds roughly to the number of samples (127) in this example).

Additionally, I thought it would be nice to be able to elide the plotting functionality in `fit` completely if it is not desired. I added an additional keyword argument that is passed through to `parameter_update`.